### PR TITLE
fix: return message from child()

### DIFF
--- a/bench/index.ts
+++ b/bench/index.ts
@@ -88,6 +88,7 @@ ROARR.write = () => {};
 			let events: any[] = [];
 			const suite = roarr.child((message) => {
 				events.push(message);
+				return message;
 			});
 			suite.info('info message');
 			return events;

--- a/bench/index.ts
+++ b/bench/index.ts
@@ -53,7 +53,8 @@ async function runner(candidates: Record<string, Function>) {
 	});
 }
 
-ROARR.write = () => {};
+// @ts-ignore
+global.ROARR.write = ROARR.write = () => {};
 
 (async function () {
 	await runner({

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"debug": "4.3.1",
 		"pino": "6.8.0",
 		"prettier": "2.2.1",
-		"roarr": "3.1.2",
+		"roarr": "3.2.0",
 		"rollup": "2.35.1",
 		"rollup-plugin-dts": "2.0.1",
 		"rollup-plugin-filesize": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"debug": "4.3.1",
 		"pino": "6.8.0",
 		"prettier": "2.2.1",
-		"roarr": "2.15.4",
+		"roarr": "3.1.2",
 		"rollup": "2.35.1",
 		"rollup-plugin-dts": "2.0.1",
 		"rollup-plugin-filesize": "9.1.0",


### PR DESCRIPTION
Updated benchmarks:

```
Validation
✔ diary
✔ ulog
✔ roarr
✔ bunyan
✔ debug
✔ pino
✔ winston

Benchmark
  diary      x 661,459 ops/sec ±1.34% (91 runs sampled)
  ulog       x 22,853 ops/sec ±44.25% (9 runs sampled)
  roarr      x 749,119 ops/sec ±12.59% (86 runs sampled)
  bunyan     x 99,588 ops/sec ±24.33% (92 runs sampled)
  debug      x 222,025 ops/sec ±3.22% (88 runs sampled)
  pino       x 49,700 ops/sec ±2.49% (91 runs sampled)
  winston    x 12,532 ops/sec ±9.64% (80 runs sampled)

```