### PR TITLE
Fix TypeScript unable to resolve types

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,14 @@
 	"main": "diary/index.js",
 	"unpkg": "diary/index.min.js",
 	"module": "diary/index.mjs",
-	"types": "types/index.d.ts",
+	"types": "index.d.ts",
+	"typesVersions": {
+		">=4": {
+			"*": [
+				"types/*"
+			]
+		}
+	},
 	"files": [
 		"types",
 		"diary",

--- a/package.json
+++ b/package.json
@@ -35,13 +35,6 @@
 	"unpkg": "diary/index.min.js",
 	"module": "diary/index.mjs",
 	"types": "types/index.d.ts",
-	"typesVersions": {
-		"*": {
-			"*": [
-				"types/*"
-			]
-		}
-	},
 	"files": [
 		"types",
 		"diary",


### PR DESCRIPTION
Fixes https://github.com/maraisr/diary/issues/9

Removes `typesVersions` field in `package.json`. If types are meant to apply to any TS version this field is not actually required.

It seams the `"*"` key is not getting picked up by TS correctly and that's what causes the types to be unresolved.