### PR TITLE
feat: nested diaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ node_modules
 /diary
 /json
 /utils
+
+# tools
+.tool-versions

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,8 @@ scopedDiary.info('this other important thing happened');
 // ~> ℹ info  [my-module] this other important thing happened
 ```
 
+
+
 Controlling runtime emission of logs:
 
 ### _browser_
@@ -110,11 +112,36 @@ scopeB1.info('message'); // won't log ✗
 scopeB2.info('message'); // won't log ✗
 ```
 
+## Inheritance
+
+```ts
+import { diary, defaultReporter } from 'diary';
+import { compare } from 'diary/utils';
+import { LogEvent } from './index';
+
+// you can combine this with localStorage or env variables to allow for configurable project-wide loglevels
+const ignoreBelowWarning = (event: LogEvent) => {
+	if (compare(event.level, "warning") > 0) {
+		defaultReporter(event);
+	}
+}
+
+const rootDiary = diary('my-project', ignoreBelowWarning);
+const scopedDiary = rootDiary.diary('scopedDiary');
+
+
+// the scope of scopedDiary is my-project:scopedDiary
+// it inherits the Reporter from its parent
+// you can also overwrite the reporter:
+
+const scopedDiaryWithCustomReporter = rootDiary.diary('scopedDiaryB', (event: LogEvent) => {/* do something else */});
+
+```
 ## 🔎 API
 
 ### diary(name: string, onEmit?: Reporter)
 
-Returns: [log functions](#log-functions)
+Returns: [log functions](#log-functions) + itself
 
 > A default diary is exported, accessible through simply importing any [log function](#log-functions).
 >
@@ -134,6 +161,8 @@ Returns: [log functions](#log-functions)
 Type: `string`
 
 The name given to this _diary_—and will also be available in all logEvents.
+If called from the result of another `diary()` call, this is automatically
+prefixed by that diary's name (see [inheritance](#inheritance)).
 
 #### onEmit <small>(optional)</small>
 
@@ -141,6 +170,8 @@ Type: `Reporter`
 
 A reporter is run on every log message (provided its [enabled](#enablequery-string)). A reporter gets given the
 `LogEvent` interface:
+
+If called from the result of another `diary()` call, this inherits that diary's onEmit argument. (see [inheritance](#inheritance))
 
 ```ts
 interface LogEvent {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,14 @@ export type Reporter = (event: LogEvent) => void;
 
 type LogFn = (message?: string, ...args: unknown[]) => void;
 type LogFnAsError = (message?: string | Error, ...args: unknown[]) => void;
+type DiaryFn = (name: string, onEmit?: Reporter) => Diary;
 
 export type LogLevels = 'fatal' | 'error' | 'warn' | 'debug' | 'info' | 'log';
 type ErrorLevels = Extract<LogLevels, 'fatal' | 'error'>;
 
-export type Diary = Record<Exclude<LogLevels, ErrorLevels>, LogFn> & Record<ErrorLevels, LogFnAsError>;
+export type Diary = Record<Exclude<LogLevels, ErrorLevels>, LogFn>
+	& Record<ErrorLevels, LogFnAsError>
+	& {diary: DiaryFn};
 
 type LogEventBase = {
 	name: string;
@@ -133,6 +136,7 @@ export function diary(name: string, onEmit?: Reporter): Diary {
 		debug: logger.bind(0, name, onEmit, 'debug'),
 		info: logger.bind(0, name, onEmit, 'info'),
 		log: logger.bind(0, name, onEmit, 'log'),
+		diary: (childName, childEmit?: Reporter) => diary(`${name}:${childName}`, childEmit ?? onEmit),
 	};
 }
 


### PR DESCRIPTION
closes #12 by implementing the 3rd proposal. It ended up being very straightforward to implement, thanks to the simple and clear codebase.

# Feature description

Allows diary inheritance by returning the `diary()` function from itself. Automatically prefixes the child diary with the name of its parent, and passes through the onEmit callback if no explicit callback is provided (similar behavior to class inheritance).

Also adds a readme section to explain the usage, and tests.
# Benchmark results:

## main branch
```
  @graphile/logger     x 20,047,626 ops/sec ±2.65% (86 runs sampled)
  bunyan               x 142,311 ops/sec ±0.29% (96 runs sampled)
  debug                x 205,040 ops/sec ±2.78% (87 runs sampled)
  diary                x 5,927,876 ops/sec ±0.95% (90 runs sampled)
  pino                 x 43,152 ops/sec ±2.02% (91 runs sampled)
  roarr                x 730,335 ops/sec ±2.00% (87 runs sampled)
  ulog                 x 22,671 ops/sec ±28.49% (17 runs sampled)
  winston              x 9,505 ops/sec ±10.77% (76 runs sampled)
  ```
  
  ## PR branch
  ```
    @graphile/logger     x 20,185,277 ops/sec ±1.80% (87 runs sampled)
  bunyan               x 132,733 ops/sec ±0.19% (97 runs sampled)
  debug                x 203,339 ops/sec ±2.80% (84 runs sampled)
  diary                x 5,634,838 ops/sec ±0.83% (93 runs sampled)
  pino                 x 45,969 ops/sec ±1.98% (93 runs sampled)
  roarr                x 746,780 ops/sec ±2.02% (87 runs sampled)
  ulog                 x 22,849 ops/sec ±25.67% (19 runs sampled)
  winston              x 10,972 ops/sec ±9.08% (83 runs sampled)
  ```