### PR TITLE
Use prepare instead of prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"bench": "cross-env TS_NODE_PROJECT=tsconfig.test.json DEBUG=standard ROARR_LOG=true node -r ts-eager/register bench/index.ts",
 		"build": "node bin/build && tsc --declaration true --emitDeclarationOnly --outDir types --rootDir src --noEmit false",
 		"format": "prettier  --write --list-different \"{*,bench/**/*,.github/**/*,test/*}.+(ts|json|yml|md)\"",
-		"prepublishOnly": "pnpm run build",
+		"prepare": "pnpm run build",
 		"test": "cross-env TS_NODE_PROJECT=tsconfig.test.json uvu -r ts-eager/register -i helpers.ts test",
 		"typecheck": "tsc --noEmit"
 	},


### PR DESCRIPTION
Since building is necessary for any kind of work on the library, it's better to use prepare instead of prepublishOnly.
I hit this usecase when trying to switch to using my diary fork as a dependency for my consuming app (we have to move too fast to wait for pr reviews). 

Reference: https://docs.npmjs.com/cli/v7/using-npm/scripts

The main difference is that prepare is also ran when installing directly from a github repo.