### PR TITLE
feat: build diary core for platform

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -3,28 +3,43 @@ const esbuild = require('esbuild');
 
 const externals = ['diary/utils', 'diary'];
 
-/**
- * @param {string} input
- * @param {Record<'import'|'require', string>} files
- */
-async function bundle(input, files) {
-	await esbuild.build({
-		entryPoints: [input],
-		bundle: true,
-		format: 'esm',
-		platform: 'neutral',
-		outfile: files.import,
-		external: externals,
-	});
+const targets = ['browser', 'worker'];
 
-	await esbuild.build({
-		entryPoints: [input],
-		bundle: true,
-		format: 'cjs',
-		platform: 'neutral',
-		outfile: files.require,
-		external: externals,
-	});
+async function bundle(input, files, env, neutral) {
+	const is_neutral_block = Object.keys(files).some(i => targets.includes(i));
+
+	for (let target of Object.keys(files)) {
+		const is_neutral = neutral === undefined
+			? !targets.includes(target)
+			: neutral;
+
+		if (!is_neutral && typeof files[target] === 'object') {
+			await bundle(input, files[target], target, is_neutral);
+
+			continue;
+		}
+
+		if (!env && is_neutral_block) env = 'node';
+
+		const format = target === 'import' ? 'esm' : 'cjs';
+		const platform = is_neutral ? 'neutral' : ((env === 'worker' ? 'browser' : env) || 'neutral');
+		const trg = env || 'neutral';
+
+		console.log('~> [%s] format: %s platform: %s target: %s', input, format, platform, trg);
+
+		await esbuild.build({
+			entryPoints: [input],
+			bundle: true,
+			format,
+			platform,
+			outfile: files[target],
+			external: externals,
+			minifySyntax: true,
+			define: {
+				__TARGET__: `"${trg}"`,
+			},
+		});
+	}
 }
 
 Promise.all([
@@ -39,5 +54,8 @@ Promise.all([
 		outfile: 'diary/index.min.js',
 		minify: true,
 		external: externals,
+		define: {
+			__TARGET__: '"browser"',
+		},
 	}),
 ]);

--- a/package.json
+++ b/package.json
@@ -18,8 +18,16 @@
 	"sideEffects": false,
 	"exports": {
 		".": {
-			"import": "./diary/index.mjs",
-			"require": "./diary/index.js"
+			"worker": {
+				"import": "./diary/worker/index.mjs",
+				"require": "./diary/worker/index.js"
+			},
+			"browser": {
+				"import": "./diary/browser/index.mjs",
+				"require": "./diary/browser/index.js"
+			},
+			"import": "./diary/node/index.mjs",
+			"require": "./diary/node/index.js"
 		},
 		"./json": {
 			"import": "./json/index.mjs",
@@ -52,7 +60,7 @@
 		"bench": "cross-env TS_NODE_PROJECT=tsconfig.test.json DEBUG=standard ROARR_LOG=true node -r ts-eager/register bench/index.ts",
 		"build": "node bin/build && tsc --emitDeclarationOnly",
 		"fmt": "prettier  --write --list-different \"{*,bench/**/*,.github/**/*,test/*}.+(ts|json|yml|md)\"",
-		"test": "cross-env TS_NODE_PROJECT=tsconfig.test.json uvu -r ts-eager/register -i helpers.ts test",
+		"test": "cross-env TS_NODE_PROJECT=tsconfig.test.json uvu -r ts-eager/register -r test/setup.js -i helpers.ts -i setup.js test",
 		"typecheck": "tsc --noEmit"
 	},
 	"prettier": {

--- a/readme.md
+++ b/readme.md
@@ -48,25 +48,7 @@ scopedDiary.info('this other important thing happened');
 
 Controlling runtime emission of logs:
 
-### _browser_
-
-```ts
-import { diary } from 'diary';
-
-localStorage.setItem('DEBUG', 'scopeA:two,scopeB:*');
-
-const scopeA1 = diary('scopeA:one');
-const scopeA2 = diary('scopeA:two');
-const scopeB1 = diary('scopeB:one');
-const scopeB2 = diary('scopeB:two');
-
-scopeA1.info('message'); // won't log ✗
-scopeA2.info('message'); // will log ✔
-scopeB1.info('message'); // will log ✔
-scopeB2.info('message'); // will log ✔
-```
-
-#### _node_
+For the code:
 
 ```ts
 // example.js
@@ -83,7 +65,27 @@ scopeB1.info('message'); // will log ✔
 scopeB2.info('message'); // will log ✔
 ```
 
-> `$ DEBUG=scopeA:two,scopeB:* node example.js`
+### _browser_
+
+```ts
+localStorage.setItem('DEBUG', 'scopeA:two,scopeB:*');
+
+// then your scripts
+```
+
+> 💡 Tip - Set this via the DevTools, then hit refresh. Saves you having to re-bundle.
+
+#### _node_
+
+```sh
+DEBUG=scopeA:two,scopeB:* node example.js
+```
+
+#### _workers_
+
+Create an [Environment Variable](https://developers.cloudflare.com/workers/platform/environments) with `DEBUG`.
+
+> ⚠️ Specifically referencing the Cloudflare Workers
 
 #### _programmatic_
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,6 @@
+declare const __TARGET__: 'browser' | 'worker' | 'node' | 'neutral';
+
+/**
+ * During workers — this can exist
+ */
+declare const DEBUG: string;

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,1 @@
+globalThis.__TARGET__ = 'node';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
 			"diary/*": ["src/*"]
 		}
 	},
-	"include": ["src/*.ts"],
+	"include": ["src/global.d.ts", "src/*.ts"],
 	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
`diary` will now build out its core `diary` module into 3 flavors, `workers | 'browser' | 'node'`. This is really to enable future improvements where logging need to go into slightly different behaviors for those runtime.