### PR TITLE
fix: provide distinct suffix declaration for common js modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,25 +20,25 @@
 			"browser": {
 				"types": "./diary/browser/index.d.ts",
 				"import": "./diary/browser/index.mjs",
-				"require": "./diary/browser/index.js"
+				"require": "./diary/browser/index.cjs"
 			},
 			"types": "./diary/node/index.d.ts",
 			"import": "./diary/node/index.mjs",
-			"require": "./diary/node/index.js"
+			"require": "./diary/node/index.cjs"
 		},
 		"./json": {
 			"types": "./json/index.d.ts",
 			"import": "./json/index.mjs",
-			"require": "./json/index.js"
+			"require": "./json/index.cjs"
 		},
 		"./utils": {
 			"types": "./utils/index.d.ts",
 			"import": "./utils/index.mjs",
-			"require": "./utils/index.js"
+			"require": "./utils/index.cjs"
 		},
 		"./package.json": "./package.json"
 	},
-	"main": "diary/node/index.js",
+	"main": "diary/node/index.cjs",
 	"module": "diary/node/index.mjs",
 	"types": "diary/node/index.d.ts",
 	"files": [


### PR DESCRIPTION
<!-- what are you solving here -->
Error: require() of ES Module
---
Using diary as an dependency within another module, this module raises an error within a node/server side env (e.g. Next.js, Nuxt.js) see picture.

![Bildschirm­foto 2023-03-13 um 09 18 54](https://user-images.githubusercontent.com/9822752/224644982-0ae7075f-a1b5-4f15-abf9-96b8916d6713.png)

Alternatively, as the error message describes, the file suffix could be still .js but the type declaration of the module itself should be changed to not being an ESM module.

Reproduction example:
https://codesandbox.io/p/sandbox/quirky-bassi-7940pf